### PR TITLE
Remove Debian bullseye from distribution list

### DIFF
--- a/dist.json
+++ b/dist.json
@@ -2,7 +2,6 @@
   "include": [
     { "dist": "ubuntu", "ver": "jammy" },
     { "dist": "ubuntu", "ver": "noble" },
-    { "dist": "debian", "ver": "bullseye" },
     { "dist": "debian", "ver": "bookworm" },
     { "dist": "debian", "ver": "trixie" }
   ]


### PR DESCRIPTION
Eliminate the Debian bullseye distribution from the include list in dist.json.